### PR TITLE
Only use alignment pragma on 32-bit machines

### DIFF
--- a/d3d8types.h
+++ b/d3d8types.h
@@ -20,7 +20,9 @@
 #include <float.h>
 
 #pragma warning(disable:4201) // anonymous unions warning
+#if defined (_WIN32) && !defined (_WIN64)
 #pragma pack(4)
+#endif
 
 // D3DCOLOR is equivalent to D3DFMT_A8R8G8B8
 #ifndef D3DCOLOR_DEFINED


### PR DESCRIPTION
Consider maybe deleting that pragma as a whole?
Unless it's found to serve some purpose of course, but "natural" alignment on 32-bit should be 4 anyways.